### PR TITLE
Add VMware vSphere ESXi host as an OVA builder option

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,23 +1,35 @@
 # Netshoot-OVA
 This is a template to have the great Netshoot project by Nicolaka (https://github.com/nicolaka/netshoot) in an OVA format. It is very useful for those situations when you require a light and fast to deploy VM to troubleshoot a faulty network or VM environment, but don't want to install a full VM. Currently, the OVA is under 600MB.
 
-The OVA is based around Alpine Linux 3.12 and can be built using [Packer](https://www.packer.io).  This Packer template will build a OVA using VirtualBox or VMware Workstation/Fusion/Player from an Alpine ISO image. Networking is configured for DHCP and an SSH user is created (default `vagrant` password `vagrant`) with sudo privileges. The default `root` password is `VMware1!`
+The OVA is based around Alpine Linux 3.12 and can be built using [Packer](https://www.packer.io). The following Packer templates will build an OVA using either VirtualBox, VMware Workstation/Fusion/Player or a VMware vSphere ESXi host from an Alpine ISO image. Networking is configured for DHCP and an SSH user is created (default `vagrant` password `vagrant`) with sudo privileges. The default `root` password is `VMware1!`
 
+---
 
-To build it using VirtualBox, use the following command
+To build it using **VirtualBox**, use the following command:
 
-    packer build netshoot-ova-virtualbox.json
+`packer build netshoot-ova-virtualbox.json`
 
-To build it using VMware, use the following command
+---
 
-    packer build netshoot-ova-vmware.json
-    
+To build it using **VMware Workstation/Fusion/Player**, use the following command:
+
+`packer build netshoot-ova-vmware.json`
+
 *Please note that the VMware-ISO builder does not allow OVF/OVA exporting from VMware Workstation/Fusion/Player. You'll have to export the VM manually after Packer has finished.*
-    
+
+---
+
+Building it using a **VMware vSphere ESXi host** *(!) requires the additional installation of the [Open Virtualization Format Tool (ovftool)](https://code.vmware.com/web/tool/4.4.0/ovf) and the use of a Packer Variable file (`-var-file=builder-host.json`). Specify your *Builder-Host* parameters in the `builder-host.json` and execute the following command:
+
+`packer build -var-file=builder-host.json netshoot-ova-esxi.json`
+
+*: Only the VMware vSphere ESXi versions 6.5 and 6.7 are supported due to the [removal of the `VNC Server` in vSphere 7.0](https://docs.vmware.com/en/VMware-vSphere/7.0/rn/vsphere-esxi-vcenter-server-70-release-notes.html).
+
+---
 
 You can customize the login username and password with:
 
-    packer build -var=ssh_username=youruser -var=ssh_password=yourpassword
+`packer build -var=ssh_username=youruser -var=ssh_password=yourpassword`
 
 Further customization is possible by overriding other variables, or editing `netshoot-ova` or `http/answers`.
 

--- a/builder-host.json
+++ b/builder-host.json
@@ -1,0 +1,7 @@
+{
+  "builder_host": "10.10.15.1",
+  "builder_host_username": "root",
+  "builder_host_password": "VMware1!",
+  "builder_host_datastore": "Datastore",
+  "builder_host_portgroup": "VM Network"
+}

--- a/netshoot-ova-esxi.json
+++ b/netshoot-ova-esxi.json
@@ -1,0 +1,89 @@
+{
+  "description": "Build base Netshoot-OVA",
+  "variables": {
+    "vm_name": "netshoot",
+    "cpus": "2",
+    "memory": "1024",
+    "disk_size": "5120",
+    "iso_local_url": "../../iso/alpine-virt-3.12.0-x86_64.iso",
+    "iso_download_url": "http://dl-cdn.alpinelinux.org/alpine/v3.12/releases/x86_64/alpine-standard-3.12.0-x86_64.iso",
+    "iso_checksum": "746a7af837fcb3451b7587e881d6706269cf4f300f7cf37964e200e50a52c93c",
+    "root_password": "VMware1!",
+    "ssh_username": "vagrant",
+    "ssh_password": "vagrant"
+  },
+  "provisioners": [
+    {
+      "type": "shell",
+      "inline": "mkdir .ssh; cd .ssh; echo ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEA6NF8iallvQVp22WDkTkyrtvp9eWW6A8YVr+kz4TjGYe7gHzIw+niNltGEFHzD8+v1I2YJ6oXevct1YeS0o9HZyN1Q9qgCgzUFtdOKLv6IedplqoPkcmF0aYet2PkEDo3MlTBckFXPITAMzF8dJSIFo9D8HfdOV0IAdx4O7PtixWKn5y2hMNG0zQPyUecp4pzC6kivAIhyfHilFR61RGL+GPXQ2MWZWFYbAGjyiYJnAmCP3NOTd0jMZEnDkbUvxhMmBYSdETk1rRgm+R4LOzFUGaHqHDLKLX+FIPKcF96hrucXzcWyLbIbEgE98OHlnVYCzRdK8jlqm8tehUc9c9WhQ== vagrant insecure public key > authorized_keys; echo vagrant insecure ssh key added!"
+    }
+  ],
+  "builders": [
+    {
+      "type": "vmware-iso",
+      "vm_name": "{{user `vm_name`}}",
+      "guest_os_type": "Other",
+      "version": "13",
+      "format": "ova",
+      "disk_size": "{{user `disk_size`}}",
+      "iso_urls": [
+        "{{user `iso_local_url`}}",
+        "{{user `iso_download_url`}}"
+      ],
+      "iso_checksum": "{{user `iso_checksum`}}",
+      "http_directory": "http",
+      "remote_type": "esx5",
+      "remote_host": "{{ user `builder_host` }}",
+      "remote_datastore": "{{ user `builder_host_datastore` }}",
+      "remote_username": "{{ user `builder_host_username` }}",
+      "remote_password": "{{ user `builder_host_password` }}",
+      "communicator": "ssh",
+      "ssh_username": "{{user `ssh_username`}}",
+      "ssh_password": "{{user `ssh_password`}}",
+      "ssh_wait_timeout": "10m",
+      "shutdown_command": "echo {{user `ssh_password`}} | sudo -S /sbin/poweroff",
+      "boot_wait": "50s",
+      "vnc_disable_password": true,
+      "vmx_data": {
+        "cpus": "{{ user `numvcpus` }}",
+        "memory": "{{ user `ramsize` }}",
+        "ethernet0.networkName": "{{ user `builder_host_portgroup` }}",
+        "ethernet0.present": "TRUE",
+        "ethernet0.startConnected": "TRUE",
+        "ethernet0.virtualDev": "e1000",
+        "ethernet0.wakeOnPcktRcv": "FALSE"
+      },
+      "boot_command": [
+        "root<enter><wait>",
+        "ifconfig eth0 up && udhcpc -i eth0<enter><wait10>",
+        "wget http://{{ .HTTPIP }}:{{ .HTTPPort }}/answers<enter><wait>",
+        "setup-alpine -f $PWD/answers<enter><wait5>",
+        "{{user `root_password`}}<enter><wait>",
+        "{{user `root_password`}}<enter><wait>",
+        "<wait20>y<enter>",
+        "<wait10><wait10><wait4m>",
+        "reboot<enter>",
+        "<wait10><wait10><wait2m>",
+        "root<enter><wait5>",
+        "{{user `root_password`}}<enter><wait5>",
+        "echo http://dl-cdn.alpinelinux.org/alpine/v3.12/community >> /etc/apk/repositories<enter>",
+        "apk add sudo<enter><wait5>",
+        "echo 'Defaults env_keep += \"http_proxy https_proxy\"' > /etc/sudoers.d/wheel<enter>",
+        "echo '%wheel ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers.d/wheel<enter>",
+        "adduser {{user `ssh_username`}}<enter><wait5>",
+        "{{user `ssh_password`}}<enter><wait>",
+        "{{user `ssh_password`}}<enter><wait>",
+        "adduser {{user `ssh_username`}} wheel<enter><wait5>",
+        "apk add virtualbox-guest-additions virtualbox-guest-modules-virt open-vm-tools<enter><wait5>",
+        "echo PermitRootLogin yes >> /etc/ssh/sshd_config<enter><wait2>",
+        "rc-update add open-vm-tools<enter><wait5>",
+        "wget -O /etc/motd http://{{ .HTTPIP }}:{{ .HTTPPort }}/motd <enter><wait5>",
+        "apk add bash<enter><wait5>",
+        "wget http://{{ .HTTPIP }}:{{ .HTTPPort }}/packages.sh<enter><wait>",
+        "bash -l $PWD/packages.sh<enter><wait>",
+        "cat /dev/null > ~/.ash_history<enter><wait>",
+        "<wait4m>"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Signed-off-by: Robert Guske <rguske@vmware.com>

This PR will add the ability to use a vSphere ESXi Host as a "Build Host" for the OVA. 

The following was successfully tested:
- [x] Build OVA in a vSphere 6.7 environment
- [x] Deploy the fresh OVA into a vSphere 7 environment
- [x] Check accessibility via `ssh` to the `netshoot-vm`

I also adjusted the README.md.